### PR TITLE
fix(core): prevent reactivity cascades in window mode methods

### DIFF
--- a/src/core/DesktopInstance.ts
+++ b/src/core/DesktopInstance.ts
@@ -104,6 +104,8 @@ export class DesktopInstance {
   minimizeWindow(id: string) {
     const win = this.getWindow(id);
     if (!win) return false;
+    // Early exit if already minimized to prevent unnecessary reactivity
+    if (this._modes.value.get(id) === "minimized") return true;
     this._modes.value.set(id, "minimized");
     triggerRef(this._modes);
     this.emit("window:minimized", { windowId: id });
@@ -113,6 +115,8 @@ export class DesktopInstance {
   maximizeWindow(id: string) {
     const win = this.getWindow(id);
     if (!win) return false;
+    // Early exit if already maximized to prevent unnecessary reactivity
+    if (this._modes.value.get(id) === "maximized") return true;
     const currentMode = this.getMode(id);
     if (currentMode === "normal") {
       const currentBounds = this.getBounds(id);
@@ -129,6 +133,8 @@ export class DesktopInstance {
   restoreWindow(id: string) {
     const win = this.getWindow(id);
     if (!win) return false;
+    // Early exit if already normal to prevent unnecessary reactivity
+    if (this._modes.value.get(id) === "normal") return true;
     const restoreBounds = this._restoreBounds.get(id);
     if (restoreBounds) {
       this._bounds.value.set(id, restoreBounds);


### PR DESCRIPTION
## Summary
- Add early-exit checks to `minimizeWindow`, `maximizeWindow`, and `restoreWindow` methods
- Prevents unnecessary `triggerRef()` calls when window is already in the target mode
- Fixes browser crashes on Firefox and Edge when rapidly minimizing/maximizing windows

## Root Cause
When mode methods were called repeatedly, they always triggered Vue's `shallowRef` reactivity even when the mode hadn't changed. On Firefox and Edge, this caused excessive reactivity cascades leading to page freezes and crashes.

## Test plan
- [x] All 268 unit tests pass
- [x] Build succeeds
- [x] Lint passes
- [x] Manual testing on Firefox and Edge to verify crashes no longer occur

🤖 Generated with [Claude Code](https://claude.com/claude-code)