### PR TITLE
chore(ci): setup dependabot for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,39 @@
+version: 2
+updates:
+  # JavaScript/TypeScript dependencies (npm/pnpm)
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      # Group minor and patch updates together
+      production-dependencies:
+        patterns:
+          - "vue"
+          - "@vue/*"
+        update-types:
+          - "minor"
+          - "patch"
+      dev-dependencies:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "vue"
+          - "@vue/*"
+        update-types:
+          - "minor"
+          - "patch"
+    commit-message:
+      prefix: "chore(deps)"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(ci)"


### PR DESCRIPTION
## Summary
- Configure Dependabot for automated dependency updates
- Check npm dependencies weekly (Mondays)
- Group minor/patch updates to reduce PR noise
- Update GitHub Actions dependencies separately
- Use conventional commit prefixes (`chore(deps)` and `chore(ci)`)

Closes #3

## Test plan
- [x] Valid YAML syntax
- [ ] Verify Dependabot PRs appear after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)