### PR TITLE
fix(release): temporarily use NPM_TOKEN for initial publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,4 +39,5 @@ jobs:
       - name: Run semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}  # Temporary: remove after first publish and switch to trusted publishing
         run: npx semantic-release

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -13,7 +13,7 @@
       "@semantic-release/npm",
       {
         "npmPublish": true,
-        "provenance": true
+        "provenance": false
       }
     ],
     [


### PR DESCRIPTION
## Summary
Temporarily add NPM_TOKEN for the first npm publish.

## Changes
- Add `NPM_TOKEN` to release workflow
- Disable `provenance` (requires OIDC, not compatible with token auth)

## Before running the release

1. Create an **Automation** token on npmjs.com:
   - Go to npmjs.com → Account Settings → Access Tokens
   - Click "Generate New Token" → Select **Automation**
   - Copy the token

2. Add to GitHub:
   - Go to repo Settings → Secrets and variables → Actions
   - Add secret: `NPM_TOKEN` with the token value

3. Merge this PR

4. Run the Release workflow manually

## After successful publish

Create a follow-up PR to:
1. Remove `NPM_TOKEN` from workflow
2. Re-enable `provenance: true` in .releaserc.json
3. Configure trusted publishing on npmjs.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)