### PR TITLE
fix(release): add NODE_AUTH_TOKEN for npm authentication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,5 +39,6 @@ jobs:
       - name: Run semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}  # Temporary: remove after first publish and switch to trusted publishing
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}  # Used by semantic-release/npm
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}  # Used by setup-node's .npmrc
         run: npx semantic-release


### PR DESCRIPTION
## Summary
Fix npm authentication by setting both environment variables:
- `NPM_TOKEN` - used by semantic-release/npm
- `NODE_AUTH_TOKEN` - used by setup-node's generated .npmrc

## Root Cause
`setup-node` with `registry-url` creates a `.npmrc` that references `NODE_AUTH_TOKEN`, but we were only setting `NPM_TOKEN`.

## Test plan
- [ ] Merge and re-run release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)