### PR TITLE
chore(release): switch to npm trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,4 @@ jobs:
       - name: Run semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}  # Used by semantic-release/npm
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}  # Used by setup-node's .npmrc
         run: npx semantic-release

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -13,7 +13,7 @@
       "@semantic-release/npm",
       {
         "npmPublish": true,
-        "provenance": false
+        "provenance": true
       }
     ],
     [


### PR DESCRIPTION
## Summary
Switch from NPM_TOKEN to trusted publishing (OIDC) for npm authentication.

## Changes
- Remove `NPM_TOKEN` and `NODE_AUTH_TOKEN` from workflow
- Re-enable `provenance: true` for attestation

## Before merging: Configure trusted publishing on npmjs.com

1. Go to **https://www.npmjs.com/package/@kiwiproject/vue-desktop/access**
2. Scroll to **Trusted Publishers** section
3. Click **Add a trusted publisher**
4. Fill in:
   - **Organization or user**: `kiwiproject`
   - **Repository**: `vue-desktop`
   - **Workflow filename**: `release.yml`
   - **Environment**: (leave blank)
5. Click **Save**

## After merging
- Delete the `NPM_TOKEN` secret from GitHub repo settings (no longer needed)

## Benefits
- No tokens to rotate or manage
- More secure (no long-lived credentials)
- Provenance attestation shows package was built from this repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)