### PR TITLE
docs: add documentation and demo links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 A lightweight Vue 3 + TypeScript desktop-style window manager library with a plugin-based architecture.
 
+**[Documentation](https://kiwiproject.github.io/vue-desktop/)** | **[Live Demo](https://kiwiproject.github.io/vue-desktop/demo/)**
+
 ## Features
 
 - **Draggable & Resizable Windows** — Move windows by title bar, resize from any edge or corner


### PR DESCRIPTION
## Summary
Add prominent links to the documentation site and live demo in the README.

## Changes
Added after the badges:
- **[Documentation](https://kiwiproject.github.io/vue-desktop/)**
- **[Live Demo](https://kiwiproject.github.io/vue-desktop/demo/)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)