### PR TITLE
Add cooldown periods to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 10
+    cooldown:
+      semver-patch-days: 5
+      semver-minor-days: 21
+      semver-major-days: 30
     groups:
       # Group minor and patch updates together
       production-dependencies:


### PR DESCRIPTION
Add cooldown periods to the Dependabot configuration to reduce noise from immediate version bump PRs. This gives time for issues with new releases to surface in the community before we adopt them. Patch: 5 days, minor: 21 days, major: 30 days.