### PR TITLE
ci: build against Node 24 and 26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node_version: ['24', '26']
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
@@ -17,10 +21,10 @@ jobs:
         with:
           version: 9
 
-      - name: Setup Node
+      - name: Setup Node ${{ matrix.node_version }}
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v6
         with:
-          node-version: '24'
+          node-version: ${{ matrix.node_version }}
           cache: 'pnpm'
 
       - name: Install dependencies


### PR DESCRIPTION
Converts ci.yml from a single pinned Node 24 build to a matrix testing both Node 24 and 26, matching the approach used in kiwi-js, kiwi-test-js, vue-dynamic-property-provider, and dynamic-properties-provider-js. Node 26 becomes LTS in October 2026.

release.yml is left pinned to Node 24 for now, since it's a single build-and-publish job rather than a separate test matrix + release job.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SgmK6SqXwnQozs7SWxY5fg)_